### PR TITLE
Increase medical menu max distance to 8 from 2

### DIFF
--- a/addons/cba_settings_userconfig/cba_settings.sqf
+++ b/addons/cba_settings_userconfig/cba_settings.sqf
@@ -266,7 +266,7 @@ force ace_medical_treatment_woundStitchTime = 5;
 force ace_medical_vitals_simulateSpO2 = true;
 
 // ACE Medical Interface
-force ace_medical_gui_maxDistance = 2;
+force ace_medical_gui_maxDistance = 8;
 force ace_medical_gui_showBleeding = 2;
 force ace_medical_gui_showBloodlossEntry = true;
 force ace_medical_gui_showDamageEntry = true;


### PR DESCRIPTION
The Range for the medical menu being so short meant my Medical was getting cancelled even while basically on top of the patient. Number is malleable it doesn't need to be 8 just at least double the normal